### PR TITLE
Added SAN mumble.chaos.jetzt to certificate of mumble; use sslkey variable

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -259,8 +259,8 @@ nodejs_install_npm_user: "root"
 murmur_icesecretread: "secret"
 murmur_welcometext: "Welcome on the {{ base_url }}-mumble server running murmur. Enjoy your stay!"
 murmur_bandwidth: "128000"
-murmur_sslcert: "/etc/ssl/certs/{{ base_url }}.crt"
-murmur_sslkey: "/etc/ssl/private/{{ base_url }}.key"
+murmur_sslcert: "/etc/ssl/certs/mumble.{{ base_url }}.crt"
+murmur_sslkey: "/etc/ssl/private/mumble.{{ base_url }}.key"
 murmur_registername: no
 
 

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -302,7 +302,7 @@
 
     - name: Make mumble certificate readable by ssl-cert group
       file:
-        path: "/etc/ssl/private/{{ base_url }}.key"
+        path: "{{ murmur_sslkey }}"
         group: "ssl-cert"
         mode: "0640"
       notify:

--- a/templates/traefik/mumble-web.yml
+++ b/templates/traefik/mumble-web.yml
@@ -8,12 +8,16 @@ http:
       middlewares:
         - "https_redirect"
     mumble-web_https:
-      rule: "Host(`mumble.{{ base_url }}`) || (Host(`{{ base_url }}`) && PathPrefix(`/mumble-web/`))"
+      rule: "Host(`mumble.{{ base_url }}`)"
       service: "mumble-web-app@file"
       entryPoints:
         - "https"
       tls:
         certResolver: "le_http"
+        domains:
+          - main: "mumble.{{ base_url }}"
+            sans:
+              - "{{ base_url }}"
   services:
     mumble-web-app:
       loadBalancer:


### PR DESCRIPTION
Certificate of mumble is now valid for `chaos.jetzt` and `mumble.chaos.jetzt`. In that process the `murmur_sslkey` variable is used in another position