### PR TITLE
Fix missing python3.7 on Ubuntu 20.04 LTS

### DIFF
--- a/roles/maubot/tasks/main.yml
+++ b/roles/maubot/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- name: Install python3.7
+- name: Install python3
   apt:
     name:
-      - "python3.7"
-      - "python3.7-venv"
+      - "python3"
+      - "python3-venv"
 
 - name: Create user
   user:
@@ -24,7 +24,7 @@
     name: "maubot"
     extra_args: "--upgrade"
     virtualenv: "/opt/venvs/maubot"
-    virtualenv_command: "/usr/bin/python3.7 -m venv"
+    virtualenv_command: "/usr/bin/python3 -m venv"
   become: yes
   become_user: "maubot"
   notify:


### PR DESCRIPTION
When doing a clean run on Ubuntu 20.04 LTS the maubot role attempts to
install `python3.7` and the corresponding venv package. In Ubuntu 20.04
however, `python3.7` is no longer available. The default is `python3.8`.
Therefore I would propose switching over to `python3` in general.

This has been testet to work on Ubuntu 20.04 LTS, but not on older
versions. Therefore, further tests need to be done.