### PR TITLE
Lower high memory usage bar

### DIFF
--- a/group_vars/all/prometheus.yml
+++ b/group_vars/all/prometheus.yml
@@ -111,7 +111,7 @@ prometheus_alert_rules:
       description: "{% raw %}{{ $labels.instance }} of job {{ $labels.job }} has Critical CPU load for more than 2 minutes.{% endraw %}"
       summary: "{% raw %}Instance {{ $labels.instance }} - Critical CPU load{% endraw %}"
   - alert: CriticalRAMUsage
-    expr: '(1 - ((node_memory_MemFree_bytes + node_memory_Buffers_bytes + node_memory_Cached_bytes) / node_memory_MemTotal_bytes)) * 100 > 98'
+    expr: '(1 - ((node_memory_MemFree_bytes + node_memory_Buffers_bytes + node_memory_Cached_bytes) / node_memory_MemTotal_bytes)) * 100 > 75'
     for: 5m
     labels:
       severity: critical


### PR DESCRIPTION
Earlier today (and over the last couple of days) the memory usage on hopper (matrix host) rose to the level that users were unable to sign in. However the monitoring has not caught that. Settings a bar of 75% free would have catched that instead of needing users to recognise that, but (regarding the last 1w[^1]) no accidental hits could be observed:

Metrics for lovelace (main host)
![screenshot_2022-09-06_19-09-26](https://user-images.githubusercontent.com/61651268/188705000-2206e3b7-c0c5-4380-8d23-1fa8a409ae28.png)

Metrics for hopper (matrix host, where the RAM filled up and we needed to manually restart `matrix-synapse`)
![screenshot_2022-09-06_19-09-46](https://user-images.githubusercontent.com/61651268/188705389-5e6f11aa-36f2-4745-abef-5964b0e51e71.png)


[^1]: Limited by our retention of 7 days