### PR TITLE
Update to Matrix 1.71.0

### DIFF
--- a/group_vars/all/matrix.yml
+++ b/group_vars/all/matrix.yml
@@ -12,7 +12,7 @@ synapse_allow_public_rooms_over_federation: true
 synapse_enable_group_creation: true
 synapse_domain: "{{ base_url }}"
 synapse_server_fqdn_matrix: "matrix.{{ synapse_domain }}"
-synapse_pip_version: "1.67.0"
+synapse_pip_version: "1.71.0"
 synapse_pip_packages_additional:
   - "git+https://github.com/chaos-jetzt/matrix-synapse-saml-mapper"
 synapse_auto_join_rooms:

--- a/group_vars/all/matrix.yml
+++ b/group_vars/all/matrix.yml
@@ -76,7 +76,7 @@ synapse_homeserver_config_extra_options: |
 
 # Element Web
 element_web_installation_path: "/var/www/riot-web"
-element_web_version: "1.11.4"
+element_web_version: "1.11.14"
 
 # Matrix-Appservice-IRC
 irc_hs_token: "{{ lookup('passwordstore', 'infra/irc-bridge subkey=hs_token') }}"

--- a/group_vars/all/matrix.yml
+++ b/group_vars/all/matrix.yml
@@ -10,10 +10,9 @@ synapse_form_secret: "{{ lookup('passwordstore', 'infra/matrix/form') }}"
 synapse_signing_key: "{{ lookup('passwordstore', 'infra/matrix/signing') }}"
 synapse_allow_public_rooms_over_federation: true
 synapse_enable_group_creation: true
-synapse_enable_registration: true
 synapse_domain: "{{ base_url }}"
 synapse_server_fqdn_matrix: "matrix.{{ synapse_domain }}"
-synapse_pip_version: "1.47.1"
+synapse_pip_version: "1.67.0"
 synapse_pip_packages_additional:
   - "git+https://github.com/chaos-jetzt/matrix-synapse-saml-mapper"
 synapse_auto_join_rooms:


### PR DESCRIPTION
**This has not been tested on dev yet.** Due to the python3.7 requirement introduced in v1.50 an upgrade on our dev host (Ubuntu 18.04 LTS, python 3.6) requires more time than I have right now. However, prod is running on Debian 10 / python 3.7 that is fine. I would strongly prefer testing this before rolling the update out to production. However, after reading the upgrade notes I do not see any significant difficulties coming. Depending on how you see it, I think we could give directly going to production a try (Of course doing proper procedure with backups before hand and making synapse unreachable until we are assured that nothing obvious broke).

From reading the change log / upgrade notes, those changes seem as if they could affect us (but in the end don't).

- v1.64.0
        - Deprecation of the ability to delegate e-mail verification to identity servers: Should not affect us (I think) due to our usage of SSO
- v1.60.0
        - Possibility for failing migrations if the database is corrupted and has duplicates: We [should be fine](https://github.com/matrix-org/synapse/issues/11779#issuecomment-1131545970) since we don't appear to have any dupes (on prod, not tested on dev):
```sql
SELECT COUNT(1) from ( SELECT state_group, prev_state_group FROM state_group_edges GROUP BY state_group, prev_state_group HAVING COUNT(ctid) > 1 ) AS dupes;
 count
-------
     0
(1 row)
```
- v1.50
        - Python 3.7 and PostgresQL 10+ requirement: Fine in prod, dev runns on Python 3.6